### PR TITLE
Allow alternate nix commands via targetBin

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@
   # "armv6l"
   # "armv7l"
   # "i686"
-] }:
+], targetBin ? "nix" }:
 
 let
 
@@ -22,31 +22,31 @@ let
         config = if arch == "armv6l" || arch == "armv7l" then "${arch}-unknown-linux-musleabi"
                  else "${arch}-unknown-linux-musl";
       };
-    }; emulator = nativePkgs.writeScript "nix" ''
-      ${pkgs.hostPlatform.emulator nativePkgs} ${pkgs.nix}/bin/nix "$@"
-    ''; in nativePkgs.runCommand "nix-${arch}" {
+    }; emulator = nativePkgs.writeScript targetBin ''
+      ${pkgs.hostPlatform.emulator nativePkgs} "${pkgs.nix}/bin/${targetBin} $@"
+    ''; in nativePkgs.runCommand "${targetBin}-${arch}" {
       nativeBuildInputs = [ nativePkgs.haskellPackages.arx ];
       passthru = { inherit (pkgs) nix; inherit emulator; };
     } ''
       # verify built binaries actually work
-      ${emulator} show-config > /dev/null
+      ${emulator} --version > /dev/null
 
       cp -r ${pkgs.nix}/share share
       chmod -R 755 share
       rm -rf share/nix/sandbox
       chmod 644 share/nix/corepkgs/*
 
-      cp ${pkgs.nix}/bin/nix nix
-      chmod 755 nix
+      cp ${pkgs.nix}/bin/${targetBin} ${targetBin}
+      chmod 755 ${targetBin}
 
-      tar cfz nix.tar.gz nix share/
+      tar cfz ${targetBin}.tar.gz ${targetBin} share/
 
       mkdir -p $out/libexec/
-      cp ${pkgs.nix}/bin/nix $out/libexec/nix-${arch}
+      cp ${pkgs.nix}/bin/${targetBin} $out/libexec/${targetBin}-${arch}
 
       mkdir -p $out/bin/
-      arx tmpx ./nix.tar.gz -o $out/bin/nix-${arch} // ${nix-runner}
-      chmod +x $out/bin/nix-${arch}
+      arx tmpx ./${targetBin}.tar.gz -o $out/bin/${targetBin}-${arch} // ${nix-runner} '"$@"'
+      chmod +x $out/bin/${targetBin}-${arch}
     '';
   }) archs);
 
@@ -58,10 +58,10 @@ let
       amd64) arch=x86_64 ;;
       armv6|armv7) arch=''${arch}l ;;
     esac
-    if [ -x ./nix-$arch ]; then
-      ./nix-$arch "$@"
+    if [ -x ./${targetBin}-$arch ]; then
+      ./${targetBin}-$arch "$@"
     else
-      ./nix "$@"
+      ./${targetBin} "$@"
     fi
   '';
 
@@ -78,11 +78,11 @@ let
 
       cp $out/libexec/* .
 
-      tar cfz nix.tar.gz nix-* share/
+      tar cfz ${targetBin}.tar.gz ${targetBin}-* share/
 
       mkdir -p $out/bin/
-      arx tmpx ./nix.tar.gz -o $out/bin/nix // ${nix-runner}
-      chmod +x $out/bin/nix
+      arx tmpx ./${targetBin}.tar.gz -o $out/bin/${targetBin} // ${nix-runner} '"$@"'
+      chmod +x $out/bin/${targetBin}
     '';
   };
 


### PR DESCRIPTION
This is the outcome of attempting to use a static nix as a nix-shell script interpreter.